### PR TITLE
Update rt_hw_us_delay example

### DIFF
--- a/zh/1chapters/03-chapter_timer.md
+++ b/zh/1chapters/03-chapter_timer.md
@@ -464,8 +464,8 @@ RT-Thread的定时器与其他实时操作系统的定时器实现稍微有些�
 高精度延时 的例程如下所示
 
 ```c
-#include <core_cm3.h>
-void rt_hw_us_delay(int us)
+#include <board.h>
+void rt_hw_us_delay(rt_uint32_t us)
 {
     rt_uint32_t delta;
 


### PR DESCRIPTION
单独include <core_cm3.h>并不能通过编译，因为core_cm3.h里面的部分类型是在其它文件定义的。
int 改为rt_uint32_t是为了跟rthw.h里面的声明保持一致